### PR TITLE
Refactor

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,8 +18,8 @@ Similarly, you can write your own `Behavior` Modules with the same logic as Pymo
     from pymonntorch import *
 
     class BasicBehavior(Behavior):
-        def set_variables(self, neurons):
-            neurons.voltage = neurons.get_neuron_vec(mode="zeros")
+        def initialize(self, neurons):
+            neurons.voltage = neurons.vector(mode="zeros")
             self.threshold = 1.0
 
         def forward(self, neurons):
@@ -28,12 +28,12 @@ Similarly, you can write your own `Behavior` Modules with the same logic as Pymo
             neurons.voltage[firing] = 0.0 # reset
             
             neurons.voltage *= 0.9 # voltage decay
-            neurons.voltage += neurons.get_neuron_vec(mode="uniform", density=0.1)
+            neurons.voltage += neurons.vector(mode="uniform", density=0.1)
 
     class InputBehavior(Behavior):
-        def set_variables(self, neurons):
+        def initialize(self, neurons):
             for synapse in neurons.afferent_synapses['GLUTAMATE']:
-                synapse.W = synapse.get_synapse_mat('uniform', density=0.1)
+                synapse.W = synapse.matrix('uniform', density=0.1)
                 synapse.enabled = synapse.W > 0
 
         def forward(self, neurons):

--- a/pymonntorch/NetworkBehavior/Basics/BasicHomeostasis.py
+++ b/pymonntorch/NetworkBehavior/Basics/BasicHomeostasis.py
@@ -63,67 +63,67 @@ class InstantHomeostasis(Behavior):
 
         setattr(object, self.adjustment_param, val)
 
-    def set_variables(self, object):
-        super().set_variables(object)
+    def initialize(self, object):
+        super().initialize(object)
 
         self.dtype = object.def_dtype
 
         self.compiled_mp = None
 
-        self.min_th = self.get_init_attr(
+        self.min_th = self.parameter(
             "min_th", None, object
         )  # minimum threshold for measurement param
-        self.max_th = self.get_init_attr(
+        self.max_th = self.parameter(
             "max_th", None, object
         )  # maximum threshold for measurement param
 
         self.set_threshold_boundaries(
-            self.get_init_attr(
+            self.parameter(
                 "threshold", None, object=object
             ),  # threshold for measurement param (min=max=th)
-            self.get_init_attr(
+            self.parameter(
                 "gap_percent", None, object=object
             ),  # min max gap is created via a percentage from th (additional param for th)
         )
 
-        self.distance_sensitive = self.get_init_attr(
+        self.distance_sensitive = self.parameter(
             "distance_sensitive", True, object
         )  # stronger adjustment when value is further away from optimum
 
         self.inc = check_is_torch_tensor(
-            self.get_init_attr("inc", 1.0, object),  # increase factor
+            self.parameter("inc", 1.0, object),  # increase factor
             device=object.device,
             dtype=self.dtype,
         )
         self.dec = check_is_torch_tensor(
-            self.get_init_attr("dec", 1.0, object),  # decrease factor
+            self.parameter("dec", 1.0, object),  # decrease factor
             device=object.device,
             dtype=self.dtype,
         )
 
         self.adj_strength = check_is_torch_tensor(
-            self.get_init_attr("adj_strength", 1.0, object),  # change factor
+            self.parameter("adj_strength", 1.0, object),  # change factor
             device=object.device,
             dtype=self.dtype,
         )
 
-        self.adjustment_param = self.get_init_attr(
+        self.adjustment_param = self.parameter(
             "adjustment_param", None, object
         )  # name of object target attribute
 
-        self.measurement_param = self.get_init_attr(
+        self.measurement_param = self.parameter(
             "measurement_param", None, object
         )  # name of parameter to be measured
 
         self.measurement_min = check_is_torch_tensor(
-            self.get_init_attr(
+            self.parameter(
                 "measurement_min", None, object
             ),  # minimum value which can be measured (below=0)
             device=object.device,
             dtype=self.dtype,
         )
         self.measurement_max = check_is_torch_tensor(
-            self.get_init_attr(
+            self.parameter(
                 "measurement_max", None, object
             ),  # maximum value which can be measured (above=max)
             device=object.device,
@@ -131,12 +131,12 @@ class InstantHomeostasis(Behavior):
         )
 
         self.target_clip_min = check_is_torch_tensor(
-            self.get_init_attr("target_clip_min", None, object),  # target clip min
+            self.parameter("target_clip_min", None, object),  # target clip min
             device=object.device,
             dtype=self.dtype,
         )
         self.target_clip_max = check_is_torch_tensor(
-            self.get_init_attr("target_clip_max", None, object),  # target clip max
+            self.parameter("target_clip_max", None, object),  # target clip max
             device=object.device,
             dtype=self.dtype,
         )
@@ -156,16 +156,16 @@ class TimeIntegratedHomeostasis(InstantHomeostasis):
         )
         return self.average
 
-    def set_variables(self, object):
-        super().set_variables(object)
+    def initialize(self, object):
+        super().initialize(object)
 
         self.integration_length = check_is_torch_tensor(
-            self.get_init_attr("integration_length", 1, object),
+            self.parameter("integration_length", 1, object),
             device=object.device,
             dtype=object.def_dtype,
         )
         self.average = check_is_torch_tensor(
-            self.get_init_attr("init_avg", (self.min_th + self.max_th) / 2, object),
+            self.parameter("init_avg", (self.min_th + self.max_th) / 2, object),
             device=object.device,
             dtype=object.def_dtype,
         )

--- a/pymonntorch/NetworkBehavior/Basics/BasicHomeostasis.py
+++ b/pymonntorch/NetworkBehavior/Basics/BasicHomeostasis.py
@@ -22,12 +22,12 @@ class InstantHomeostasis(Behavior):
                 if has_min:
                     self.min_th -= self.min_th / 100 * gap_percent
                     check_is_torch_tensor(
-                        self.min_th, device=self.device, dtype=torch.float32
+                        self.min_th, device=self.device, dtype=self.dtype
                     )
                 if has_max:
                     self.max_th += self.max_th / 100 * gap_percent
                     check_is_torch_tensor(
-                        self.max_th, device=self.device, dtype=torch.float32
+                        self.max_th, device=self.device, dtype=self.dtype
                     )
 
     def get_measurement_param(self, object):
@@ -35,7 +35,7 @@ class InstantHomeostasis(Behavior):
             self.compiled_mp = compile(self.measurement_param, "<string>", "eval")
 
         result = check_is_torch_tensor(
-            eval(self.compiled_mp), device=object.device, dtype=torch.float32
+            eval(self.compiled_mp), device=object.device, dtype=self.dtype
         )
 
         result.clamp_(self.measurement_min, self.measurement_max)
@@ -55,7 +55,7 @@ class InstantHomeostasis(Behavior):
         val = check_is_torch_tensor(
             getattr(object, self.adjustment_param),
             device=object.device,
-            dtype=torch.float32,
+            dtype=self.dtype,
         )
         val.add_(adj)
 
@@ -65,6 +65,8 @@ class InstantHomeostasis(Behavior):
 
     def set_variables(self, object):
         super().set_variables(object)
+
+        self.dtype = object.def_dtype
 
         self.compiled_mp = None
 
@@ -91,18 +93,18 @@ class InstantHomeostasis(Behavior):
         self.inc = check_is_torch_tensor(
             self.get_init_attr("inc", 1.0, object),  # increase factor
             device=object.device,
-            dtype=torch.float32,
+            dtype=self.dtype,
         )
         self.dec = check_is_torch_tensor(
             self.get_init_attr("dec", 1.0, object),  # decrease factor
             device=object.device,
-            dtype=torch.float32,
+            dtype=self.dtype,
         )
 
         self.adj_strength = check_is_torch_tensor(
             self.get_init_attr("adj_strength", 1.0, object),  # change factor
             device=object.device,
-            dtype=torch.float32,
+            dtype=self.dtype,
         )
 
         self.adjustment_param = self.get_init_attr(
@@ -118,25 +120,25 @@ class InstantHomeostasis(Behavior):
                 "measurement_min", None, object
             ),  # minimum value which can be measured (below=0)
             device=object.device,
-            dtype=torch.float32,
+            dtype=self.dtype,
         )
         self.measurement_max = check_is_torch_tensor(
             self.get_init_attr(
                 "measurement_max", None, object
             ),  # maximum value which can be measured (above=max)
             device=object.device,
-            dtype=torch.float32,
+            dtype=self.dtype,
         )
 
         self.target_clip_min = check_is_torch_tensor(
             self.get_init_attr("target_clip_min", None, object),  # target clip min
             device=object.device,
-            dtype=torch.float32,
+            dtype=self.dtype,
         )
         self.target_clip_max = check_is_torch_tensor(
             self.get_init_attr("target_clip_max", None, object),  # target clip max
             device=object.device,
-            dtype=torch.float32,
+            dtype=self.dtype,
         )
 
     def forward(self, object):
@@ -160,10 +162,10 @@ class TimeIntegratedHomeostasis(InstantHomeostasis):
         self.integration_length = check_is_torch_tensor(
             self.get_init_attr("integration_length", 1, object),
             device=object.device,
-            dtype=torch.float32,
+            dtype=object.def_dtype,
         )
         self.average = check_is_torch_tensor(
             self.get_init_attr("init_avg", (self.min_th + self.max_th) / 2, object),
             device=object.device,
-            dtype=torch.float32,
+            dtype=object.def_dtype,
         )

--- a/pymonntorch/NetworkBehavior/Basics/Normalization.py
+++ b/pymonntorch/NetworkBehavior/Basics/Normalization.py
@@ -15,10 +15,10 @@ class SynapticNormalization(Behavior):
         self.norm_factor = check_is_torch_tensor(
             self.get_init_attr("norm_factor", 1.0, neurons),
             device=neurons.device,
-            dtype=torch.float32,
+            dtype=neurons.def_dtype,
         )
 
-        neurons.sum_w = neurons.get_neuron_vec(kwargs={"dtype": torch.float32})
+        neurons.sum_w = neurons.get_neuron_vec(kwargs={"dtype": neurons.def_dtype})
 
     def forward(self, neurons):
         neurons.sum_w.zero_()

--- a/pymonntorch/NetworkBehavior/Basics/Normalization.py
+++ b/pymonntorch/NetworkBehavior/Basics/Normalization.py
@@ -5,20 +5,20 @@ from pymonntorch.utils import check_is_torch_tensor
 
 
 class SynapticNormalization(Behavior):
-    def set_variables(self, neurons):
-        super().set_variables(neurons)
+    def initialize(self, neurons):
+        super().initialize(neurons)
 
-        self.synapse_type = self.get_init_attr("synapse_type", "glutamate", neurons)
+        self.synapse_type = self.parameter("synapse_type", "glutamate", neurons)
 
         neurons.require_synapses(self.synapse_type)
 
         self.norm_factor = check_is_torch_tensor(
-            self.get_init_attr("norm_factor", 1.0, neurons),
+            self.parameter("norm_factor", 1.0, neurons),
             device=neurons.device,
             dtype=neurons.def_dtype,
         )
 
-        neurons.sum_w = neurons.get_neuron_vec(kwargs={"dtype": neurons.def_dtype})
+        neurons.sum_w = neurons.vector(kwargs={"dtype": neurons.def_dtype})
 
     def forward(self, neurons):
         neurons.sum_w.zero_()

--- a/pymonntorch/NetworkBehavior/EulerEquationModules/Equation.py
+++ b/pymonntorch/NetworkBehavior/EulerEquationModules/Equation.py
@@ -8,12 +8,12 @@ import torch
 
 
 class Equation(Behavior):
-    def set_variables(self, neurons):
-        super().set_variables(neurons)
+    def initialize(self, neurons):
+        super().initialize(neurons)
         n = neurons
         self.add_tag("EquationModule")
-        self.step_size = self.get_init_attr("step_size", "1*ms", neurons)
-        eq_parts = eq_split(self.get_init_attr("eq", None))
+        self.step_size = self.parameter("step_size", "1*ms", neurons)
+        eq_parts = eq_split(self.parameter("eq", None))
 
         if (
             eq_parts[0][0] == "d"

--- a/pymonntorch/NetworkBehavior/EulerEquationModules/EulerClock.py
+++ b/pymonntorch/NetworkBehavior/EulerEquationModules/EulerClock.py
@@ -4,13 +4,13 @@ from sympy.physics.units import convert_to, second, seconds
 
 
 class Clock(Behavior):
-    def set_variables(self, neuron_or_network):
-        super().set_variables(neuron_or_network)
+    def initialize(self, neuron_or_network):
+        super().initialize(neuron_or_network)
 
         self.add_tag("Clock")
 
         neuron_or_network.clock_step_size = float(
-            convert_to(eval(self.get_init_attr("step", "1*ms")), seconds) / second
+            convert_to(eval(self.parameter("step", "1*ms")), seconds) / second
         )  # in ms (*ms)
         self.clock_step_size = neuron_or_network.clock_step_size
         print(neuron_or_network.clock_step_size)

--- a/pymonntorch/NetworkBehavior/EulerEquationModules/VariableInitializer.py
+++ b/pymonntorch/NetworkBehavior/EulerEquationModules/VariableInitializer.py
@@ -6,12 +6,12 @@ from pymonntorch.NetworkBehavior.EulerEquationModules.Helper import (
 
 
 class Variable(Behavior):
-    def set_variables(self, neurons):
-        super().set_variables(neurons)
+    def initialize(self, neurons):
+        super().initialize(neurons)
 
         n = neurons
 
-        eq_parts = eq_split(self.get_init_attr("eq", None))
+        eq_parts = eq_split(self.parameter("eq", None))
 
         if eq_parts[1] == "=" and len(eq_parts) >= 3:
             self.var_name = eq_parts[0]
@@ -24,11 +24,9 @@ class Variable(Behavior):
 
         self.var_init = "".join(eq_parts[2:])
 
-        setattr(n, self.var_name, neurons.get_neuron_vec() + eval(self.var_init))
+        setattr(n, self.var_name, neurons.vector() + eval(self.var_init))
 
-        setattr(
-            n, self.var_name + "_new", neurons.get_neuron_vec() + eval(self.var_init)
-        )
+        setattr(n, self.var_name + "_new", neurons.vector() + eval(self.var_init))
 
     def forward(self, n):
         setattr(
@@ -37,10 +35,10 @@ class Variable(Behavior):
 
 
 class SynapseVariable(Behavior):
-    def set_variables(self, synapse):
+    def initialize(self, synapse):
         s = synapse
 
-        eq_parts = eq_split(self.get_init_attr("eq", None))
+        eq_parts = eq_split(self.parameter("eq", None))
 
         if eq_parts[1] == "=" and len(eq_parts) >= 3:
             self.var_name = eq_parts[0]
@@ -53,11 +51,9 @@ class SynapseVariable(Behavior):
 
         self.var_init = "".join(eq_parts[2:])
 
-        setattr(s, self.var_name, synapse.get_synapse_mat() + eval(self.var_init))
+        setattr(s, self.var_name, synapse.matrix() + eval(self.var_init))
 
-        setattr(
-            s, self.var_name + "_new", synapse.get_synapse_mat() + eval(self.var_init)
-        )
+        setattr(s, self.var_name + "_new", synapse.matrix() + eval(self.var_init))
 
     def forward(self, s):
         setattr(

--- a/pymonntorch/NetworkBehavior/Recorder/Recorder.py
+++ b/pymonntorch/NetworkBehavior/Recorder/Recorder.py
@@ -210,10 +210,10 @@ class EventRecorder(Recorder):
 
         data = eval(self.compiled[variable])
 
-        indices = torch.where(data != 0)[0]
-        iteration = torch.ones_like(indices) * parent_obj.iteration
+        indices = torch.where(data != 0)
+        iteration = torch.ones_like(indices[0]) * parent_obj.iteration
 
-        return torch.stack((iteration, indices), dim=1)
+        return torch.stack((iteration, *indices), dim=1)
 
     def save_data_v(self, data, variable):
         self.variables[variable] = torch.concat([self.variables[variable], data])

--- a/pymonntorch/NetworkBehavior/Recorder/Recorder.py
+++ b/pymonntorch/NetworkBehavior/Recorder/Recorder.py
@@ -53,7 +53,7 @@ class Recorder(Behavior):
         self.reset()
 
     def add_variable(self, v):
-        self.variables[v] = torch.tensor([], device=self.device)
+        self.variables[v] = torch.tensor([], dtype=torch.bool, device=self.device)
         self.compiled[v] = None
 
     def add_variables(self, vars):
@@ -86,8 +86,6 @@ class Recorder(Behavior):
         return copy.copy(eval(self.compiled[variable]))
 
     def save_data_v(self, data, variable):
-        if self.variables[variable].dtype != data.dtype:
-            self.variables[variable].to(data.dtype)
         self.variables[variable] = torch.concat(
             (self.variables[variable], data.unsqueeze(0)), dim=0
         )
@@ -177,13 +175,18 @@ class Recorder(Behavior):
             del self.variables[v]
             if device.type == "cuda":
                 torch.cuda.empty_cache()
-            self.variables[v] = torch.tensor([], device=device)
+            self.variables[v] = torch.tensor([], dtype=torch.bool, device=device)
 
 
 class EventRecorder(Recorder):
     def __init__(self, variables, tag=None, auto_annotate=True, device="cpu"):
         super().__init__(
-            variables, gap_width=0, tag=tag, max_length=None, auto_annotate=auto_annotate, device=device
+            variables,
+            gap_width=0,
+            tag=tag,
+            max_length=None,
+            auto_annotate=auto_annotate,
+            device=device,
         )
 
     def find_objects(self, key):

--- a/pymonntorch/NetworkBehavior/Recorder/Recorder.py
+++ b/pymonntorch/NetworkBehavior/Recorder/Recorder.py
@@ -1,6 +1,5 @@
 import copy
 import torch
-import warnings
 from pymonntorch.NetworkCore.Behavior import Behavior
 
 
@@ -86,6 +85,12 @@ class Recorder(Behavior):
         return copy.copy(eval(self.compiled[variable]))
 
     def save_data_v(self, data, variable):
+        if self.variables[variable].dtype != data.dtype and torch.numel(
+            self.variables[variable]
+        ):
+            print(
+                f"WARNING: The recorder received new data with a different datatype({data.dtype}) from the previously recorded data({self.variables[variable].dtype})."
+            )
         self.variables[variable] = torch.concat(
             (self.variables[variable], data.unsqueeze(0)), dim=0
         )

--- a/pymonntorch/NetworkBehavior/Recorder/Recorder.py
+++ b/pymonntorch/NetworkBehavior/Recorder/Recorder.py
@@ -29,7 +29,7 @@ class Recorder(Behavior):
 
         self.add_tag("recorder")
 
-        self.gap_width = self.get_init_attr("gap_width", 0)
+        self.gap_width = self.parameter("gap_width", 0)
         self.counter = 0
         self.new_data_available = False
 
@@ -39,13 +39,13 @@ class Recorder(Behavior):
         self.variables = {}
         self.compiled = {}
 
-        self.add_variables(self.get_init_attr("variables", []))
+        self.add_variables(self.parameter("variables", []))
         self.reset()
-        self.max_length = self.get_init_attr("max_length", None)
+        self.max_length = self.parameter("max_length", None)
 
         self.auto_annotate = auto_annotate
 
-    def set_variables(self, object):
+    def initialize(self, object):
         assert (
             self.device == object.device
         ), f"Recorder({self.device}) and object({object.device}) must be on the same device"

--- a/pymonntorch/NetworkBehavior/Recorder/Recorder.py
+++ b/pymonntorch/NetworkBehavior/Recorder/Recorder.py
@@ -53,7 +53,7 @@ class Recorder(Behavior):
         self.reset()
 
     def add_variable(self, v):
-        self.variables[v] = torch.tensor([], dtype=torch.float32, device=self.device)
+        self.variables[v] = torch.tensor([], device=self.device)
         self.compiled[v] = None
 
     def add_variables(self, vars):
@@ -86,6 +86,8 @@ class Recorder(Behavior):
         return copy.copy(eval(self.compiled[variable]))
 
     def save_data_v(self, data, variable):
+        if self.variables[variable].dtype != data.dtype:
+            self.variables[variable].to(data.dtype)
         self.variables[variable] = torch.concat(
             (self.variables[variable], data.unsqueeze(0)), dim=0
         )
@@ -175,7 +177,7 @@ class Recorder(Behavior):
             del self.variables[v]
             if device.type == "cuda":
                 torch.cuda.empty_cache()
-            self.variables[v] = torch.tensor([], dtype=torch.float32, device=device)
+            self.variables[v] = torch.tensor([], device=device)
 
 
 class EventRecorder(Recorder):

--- a/pymonntorch/NetworkBehavior/Recorder/Recorder.py
+++ b/pymonntorch/NetworkBehavior/Recorder/Recorder.py
@@ -209,15 +209,11 @@ class EventRecorder(Recorder):
         synapse = parent_obj
 
         data = eval(self.compiled[variable])
-        indices = torch.where(data != 0)[0]
 
-        if len(indices) > 0:
-            result = []
-            for i in indices:
-                result.append([parent_obj.iteration, i])
-            return torch.tensor(result, device=self.device)
-        else:
-            return None
+        indices = torch.where(data != 0)[0]
+        iteration = torch.ones_like(indices) * parent_obj.iteration
+
+        return torch.stack((iteration, indices), dim=1)
 
     def save_data_v(self, data, variable):
         self.variables[variable] = torch.concat([self.variables[variable], data])

--- a/pymonntorch/NetworkBehavior/Structure/Structure.py
+++ b/pymonntorch/NetworkBehavior/Structure/Structure.py
@@ -10,12 +10,12 @@ def vec_to_mat_transposed(vec, repeat_count):
     return torch.stack([vec] * repeat_count, dim=1)
 
 
-def rotation_matrix(axis, theta):
+def rotation_matrix(axis, theta, dtype=torch.float):
     """
     Return the rotation matrix associated with counterclockwise rotation about
     the given axis by theta radians.
     """
-    axis = torch.tensor(axis, dtype=torch.float)
+    axis = torch.tensor(axis, dtype=dtype)
     axis = axis / torch.sqrt(torch.dot(axis, axis))
     a = torch.cos(theta / 2.0)
     b, c, d = -axis * torch.sin(theta / 2.0)
@@ -55,7 +55,7 @@ class NeuronDimension(Behavior):
     def set_position(self, width, height, depth):
         self.neurons.x = (
             torch.arange(
-                0, self.neurons.size, dtype=torch.float32, device=self.neurons.device
+                0, self.neurons.size, dtype=self.neurons.def_dtype, device=self.neurons.device
             )
             % width
         )
@@ -64,7 +64,7 @@ class NeuronDimension(Behavior):
                 torch.arange(
                     0,
                     self.neurons.size,
-                    dtype=torch.float32,
+                    dtype=self.neurons.def_dtype,
                     device=self.neurons.device,
                 ),
                 width,
@@ -77,7 +77,7 @@ class NeuronDimension(Behavior):
                 torch.arange(
                     0,
                     self.neurons.size,
-                    dtype=torch.float32,
+                    dtype=self.neurons.def_dtype,
                     device=self.neurons.device,
                 ),
                 (width * height),
@@ -108,13 +108,13 @@ class NeuronDimension(Behavior):
         big_x_mat = torch.stack(
             [torch.arange(wup)] * hup,
             dim=0,
-            dtype=torch.float,
+            dtype=self.neurons.def_dtype,
             device=self.neurons.device,
         )
         big_x_mat = big_x_mat.repeat(depth, 1).flatten()
 
         big_y_mat = torch.repeat_interleave(
-            torch.arange(wup, dtype=torch.float, device=self.neurons.device),
+            torch.arange(wup, dtype=self.neurons.def_dtype, device=self.neurons.device),
             hup * depth,
         )
 
@@ -146,7 +146,7 @@ class NeuronDimension(Behavior):
         return self
 
     def rotate(self, axis, angle):
-        rotation = rotation_matrix(axis, angle)
+        rotation = rotation_matrix(axis, angle, self.neurons.def_dtype)
         self.neurons.x, self.neurons.y, self.neurons.z = torch.matmul(
             rotation, torch.stack([self.neurons.x, self.neurons.y, self.neurons.z])
         )

--- a/pymonntorch/NetworkBehavior/Structure/Structure.py
+++ b/pymonntorch/NetworkBehavior/Structure/Structure.py
@@ -49,13 +49,15 @@ def get_squared_dim(n_neurons, depth=1):
 
 
 class NeuronDimension(Behavior):
-
-    set_variables_on_init = True
+    initialize_on_init = True
 
     def set_position(self, width, height, depth):
         self.neurons.x = (
             torch.arange(
-                0, self.neurons.size, dtype=self.neurons.def_dtype, device=self.neurons.device
+                0,
+                self.neurons.size,
+                dtype=self.neurons.def_dtype,
+                device=self.neurons.device,
             )
             % width
         )
@@ -163,14 +165,14 @@ class NeuronDimension(Behavior):
             z_stretch = target_neurons.depth / self.neurons.depth
             self.neurons.z *= z_stretch
 
-    def set_variables(self, neurons):
-        super().set_variables(neurons)
+    def initialize(self, neurons):
+        super().initialize(neurons)
 
-        self.width = self.get_init_attr("width", 1, neurons)
-        self.height = self.get_init_attr("height", 1, neurons)
-        self.depth = self.get_init_attr("depth", 1, neurons)
+        self.width = self.parameter("width", 1, neurons)
+        self.height = self.parameter("height", 1, neurons)
+        self.depth = self.parameter("depth", 1, neurons)
 
-        for pg in self.get_init_attr("input_patterns", torch.tensor([]), neurons):
+        for pg in self.parameter("input_patterns", torch.tensor([]), neurons):
             dim = pg.size()
             if len(dim) > 0:
                 self.height = max(self.height, dim[0])
@@ -192,7 +194,7 @@ class NeuronDimension(Behavior):
 
         self.set_position(self.width, self.height, self.depth)
 
-        if self.get_init_attr("centered", True, neurons):
+        if self.parameter("centered", True, neurons):
             self.move(
                 -(self.width - 1) / 2, -(self.height - 1) / 2, -(self.depth - 1) / 2
             )

--- a/pymonntorch/NetworkCore/AnalysisModule.py
+++ b/pymonntorch/NetworkCore/AnalysisModule.py
@@ -10,10 +10,10 @@ from pymonntorch.NetworkCore.Base import *
 
 class AnalysisModule(TaggableObject):
     """This class can be used to add tag-searchable functions to the neurongroups, synapsegroups and the network object.
-    
+
     It has a main execute function which can be called with module(...) or module.exec(...).
     Other "normal" functions can be added as well. Via the add_tag function, the modules can be categorized into groups.
-    
+
     Attributes:
         parent (NeuronGroup, SynapseGroup or Network): The parent object.
         init_kwargs (dict): The arguments passed to the constructor.
@@ -25,9 +25,10 @@ class AnalysisModule(TaggableObject):
         update_notifier_functions (list): The list of the update notifier functions.
         progress_update_function (function): The function to update the progress.
     """
+
     def __init__(self, parent=None, **kwargs):
         self.init_kwargs = kwargs
-        super().__init__(tag=self.get_init_attr("tag", None))
+        super().__init__(tag=self.parameter("tag", None))
 
         self.used_attr_keys = []
 
@@ -48,7 +49,7 @@ class AnalysisModule(TaggableObject):
 
     def add_progress_update_function(self, function):
         """Adds a function to update the progress of the module.
-        
+
         Args:
             function (function): The function to update the progress.
         """
@@ -65,7 +66,7 @@ class AnalysisModule(TaggableObject):
 
     def _attach_and_initialize_(self, parent):
         """Attaches the module to the parent object and initializes it.
-        
+
         Args:
             parent (NeuronGroup, SynapseGroup or Network): The parent object.
         """
@@ -77,21 +78,19 @@ class AnalysisModule(TaggableObject):
     def initialize(self, object):
         """This function is called when the module is attached to the parent object. It should be overridden.
 
-        - access arguments via self.get_init_attr(key, default)
+        - access arguments via self.parameter(key, default)
         - add tag via self.add_tag(tag)
         - add execution arguments via self.add_execution_argument(...)
         `execute` does not have to be used.
-        
+
         Args:
             object (NeuronGroup, SynapseGroup or Network): The parent object.
         """
         return
 
-    def execute(
-        self, object, **kwargs
-    ):  
+    def execute(self, object, **kwargs):
         """Executes the functions of the module with the given arguments. It should be overridden.
-        
+
         Note: Do not call this function directly. Use the instance(...) instead of instance.execute(...).
 
         Args:
@@ -103,9 +102,9 @@ class AnalysisModule(TaggableObject):
     def is_executable(self):
         return type(self).execute != AnalysisModule.execute
 
-    def get_init_attr(self, key, default):
+    def parameter(self, key, default):
         """Returns the value of the given key from the init arguments. If the key is not present, the default value is returned.
-        
+
         Args:
             key (str): The name of the argument.
             default (any): The default value.
@@ -124,7 +123,7 @@ class AnalysisModule(TaggableObject):
 
     def remove_update_notifier(self, function):
         """Removes the given function from the update notifier functions.
-        
+
         Args:
             function (function): The function to remove.
         """
@@ -133,7 +132,7 @@ class AnalysisModule(TaggableObject):
 
     def set_update_notifier(self, function):
         """Adds the given function ro the list of update notifier functions.
-        
+
         Args:
             function (function): The function to set.
         """
@@ -146,10 +145,10 @@ class AnalysisModule(TaggableObject):
 
     def exec(self, **kwargs):
         """Executes the module with the given arguments.
-        
+
         Args:
             **kwargs: The arguments of the function.
-        
+
         Returns:
             any: The result of the function.
         """
@@ -157,12 +156,16 @@ class AnalysisModule(TaggableObject):
         self.current_key = self.generate_current_key(kwargs)
         return self.save_result(self.current_key, self.execute(self.parent, **kwargs))
 
-    def _get_base_name_(self):
+    def _get_name(self):
         return self.__class__.__name__
+
+    def _get_base_name(self):
+        args = [str(v) for v in self.init_kwargs.values()]
+        return self._get_name() + "(" + ", ".join(args) + ")"
 
     def generate_current_key(self, args_key, add_args=True):
         """Generates the key for the current execution.
-        
+
         Args:
             args_key (list): The arguments of the function.
             add_args (bool): If the arguments should be added to the key.
@@ -174,11 +177,11 @@ class AnalysisModule(TaggableObject):
 
     def save_result(self, key, result):
         """Saves the result of the execution.
-        
+
         Args:
             key (str): The key of the execution.
             result (any): The result of the execution.
-        
+
         Returns:
             any: The result of the execution.
         """
@@ -199,7 +202,7 @@ class AnalysisModule(TaggableObject):
 
     def remove_result(self, key):
         """Removes the result of the given key from the dictionary of results.
-        
+
         Args:
             key (str): The key of the execution to remove.
         """

--- a/pymonntorch/NetworkCore/Base.py
+++ b/pymonntorch/NetworkCore/Base.py
@@ -186,10 +186,10 @@ class NetworkObject(TaggableObject):
         Returns:
             torch.Tensor: The shifted tensor.
         """
-        mat = mat.roll(1-(2*counter), dims=0)
+        mat = mat.roll(1 - (2 * counter), dims=0)
 
         if new is not None:
-            mat[0-counter] = new
+            mat[0 - counter] = new
 
         return mat
 
@@ -214,12 +214,8 @@ class NetworkObject(TaggableObject):
 
         Returns:
             torch.Tensor: The initialized tensor."""
-        use_def_dtype = True
 
-        if mode.startswith("torch."):
-            prefix = ''
-        else:
-            prefix = "torch."
+        prefix = "torch."
 
         if mode == "random" or mode == "rand" or mode == "rnd" or mode == "uniform":
             mode = "rand"
@@ -230,18 +226,15 @@ class NetworkObject(TaggableObject):
         mode = prefix + mode
         if "(" not in mode and ")" not in mode:
             mode += "()"
-        
+
         if dtype is not None:
-            mode = mode.replace("(", f"(dtype={dtype}")
-            use_def_dtype = False
+            mode = mode.replace(")", f",dtype={dtype})")
+        else:
+            mode = mode.replace(")", f",dtype={self.def_dtype})")
 
         if mode not in self._mat_eval_dict:
             a1 = "dim,device=" + f"'{self.device}'"
             ev_str = mode.replace("(", "(" + a1)
-
-            if use_def_dtype:
-                ev_str += '.to(self.def_dtype)'
-
             self._mat_eval_dict[mode] = compile(ev_str, "<string>", "eval")
 
         result = eval(self._mat_eval_dict[mode])
@@ -296,4 +289,3 @@ class NetworkObject(TaggableObject):
                 "WARNING: Attempting to set an invalid value for iteration!\n Setting iteration to zero..."
             )
             self._iteration = 0
-            

--- a/pymonntorch/NetworkCore/Network.py
+++ b/pymonntorch/NetworkCore/Network.py
@@ -17,9 +17,9 @@ class Network(NetworkObject):
         NeuronGroups (list): List of all NeuronGroups in the network.
         SynapseGroups (list): List of all SynapseGroups in the network.
         behavior (list or dict): List of all network-specific behaviors.
-        device (str): Device to run the simulation on. Either 'cpu' or 'cuda'.
+        settings (dict): Dictionary of network-wide settings, e.g. `def_dtype` and `device`.
     """
-    def __init__(self, tag=None, behavior={}, device="cpu"):
+    def __init__(self, tag=None, behavior={}, settings={}):
         """Initialize the network.
 
         Args:
@@ -27,12 +27,17 @@ class Network(NetworkObject):
             behavior (list or dict): List or dictionary of behaviors. If a dictionary is used, the keys must be integers.
             device (str): Device on which the network is located. The default is "cpu".
         """
-        super().__init__(tag, self, behavior, device=device)
+        self.apply_settings(settings)
+        super().__init__(tag, self, behavior, device=self.device)
 
         self.NeuronGroups = []
         self.SynapseGroups = []
 
         self._iteration = 0
+
+    def apply_settings(self, settings):
+        self.device = settings.get('device', 'cpu')
+        self.def_dtype = settings.get('dtype', torch.float32)
 
     def set_behaviors(self, tag, enabled):
         """Set behaviors of specific tag to be enabled or disabled.

--- a/pymonntorch/NetworkCore/Network.py
+++ b/pymonntorch/NetworkCore/Network.py
@@ -351,7 +351,7 @@ class Network(NetworkObject):
             self.simulate_iteration()
 
         if disable_recording:
-            self.recording_on()
+            self.recording_off()
 
         if measure_block_time:
             print("")

--- a/pymonntorch/NetworkCore/Network.py
+++ b/pymonntorch/NetworkCore/Network.py
@@ -351,7 +351,7 @@ class Network(NetworkObject):
             self.simulate_iteration()
 
         if disable_recording:
-            self.recording_off()
+            self.recording_on()
 
         if measure_block_time:
             print("")

--- a/pymonntorch/NetworkCore/NeuronGroup.py
+++ b/pymonntorch/NetworkCore/NeuronGroup.py
@@ -66,6 +66,14 @@ class NeuronGroup(NetworkObject):
 
         self.id = torch.arange(self.size, device=self.device)
 
+    @property
+    def def_dtype(self):
+        self.network.def_dtype
+
+    @property
+    def iteration(self):
+        return self.network.iteration
+
     def require_synapses(self, name, afferent=True, efferent=True, warning=True):
         """Require the existence of synapses.
 
@@ -85,9 +93,7 @@ class NeuronGroup(NetworkObject):
                 print("warning: no efferent {} synapses found".format(name))
             self.efferent_synapses[name] = []
 
-    def get_neuron_vec(
-        self, mode="zeros()", scale=None, density=None, plot=False, dtype=None
-    ):
+    def vector(self, mode="zeros()", scale=None, density=None, plot=False, dtype=None):
         """Get a tensor with population's dimensionality.
 
         The tensor can be initialized in different modes. List of possible values for mode includes:
@@ -116,7 +122,7 @@ class NeuronGroup(NetworkObject):
             dtype=dtype,
         )
 
-    def get_neuron_vec_buffer(self, buffer_size, **kwargs):
+    def vector_buffer(self, buffer_size, **kwargs):
         """Get a buffer for the population's dimensionality.
 
         Args:
@@ -140,11 +146,11 @@ class NeuronGroup(NetworkObject):
         """
         source_num = 0
         for syn in self.afferent_synapses[Synapse_ID]:
-            _, s = syn.get_synapse_mat_dim()
+            _, s = syn.matrix_dim()
             source_num += s
         return self.size, source_num
 
-    def __repr__(self):
+    def __str__(self):
         result = "NeuronGroup" + str(self.tags) + "(" + str(self.size) + "){"
         for k in sorted(list(self.behavior.keys())):
             result += str(k) + ":" + str(self.behavior[k])

--- a/pymonntorch/NetworkCore/NeuronGroup.py
+++ b/pymonntorch/NetworkCore/NeuronGroup.py
@@ -7,7 +7,7 @@ from pymonntorch.NetworkCore.Behavior import *
 
 class NeuronGroup(NetworkObject):
     """This is the class to construct a neuronal population.
-    
+
     Attributes:
         size (int): The number of neurons in the population.
         behavior (list or dict): The behaviors of the population.
@@ -21,9 +21,10 @@ class NeuronGroup(NetworkObject):
         recording (bool): Whether to enable recording for the population.
         id (torch.Tensor): The integer id of the population.
     """
+
     def __init__(self, size, behavior, net, tag=None):
         """Initialize the neuronal population.
-        
+
         Args:
             size (int or Behavior): The size or dimension of the population.
             behavior (list or dict): The behaviors of the population.
@@ -67,7 +68,7 @@ class NeuronGroup(NetworkObject):
 
     def require_synapses(self, name, afferent=True, efferent=True, warning=True):
         """Require the existence of synapses.
-        
+
         Args:
             name (str): The name of the synapse.
             afferent (bool): Whether to require afferent synapses.
@@ -117,19 +118,20 @@ class NeuronGroup(NetworkObject):
 
     def get_neuron_vec_buffer(self, buffer_size, **kwargs):
         """Get a buffer for the population's dimensionality.
-        
+
         Args:
             buffer_size (int): The size of the buffer.
-            **dtype (torch.dtype, optional): The desired data type of returned tensor. 
-        
+            **dtype (torch.dtype, optional): The desired data type of returned tensor.
+
         Returns:
             torch.Tensor: The buffer.
         """
+        kwargs.setdefault("dtype", self.def_dtype)
         return self.get_buffer_mat((self.size,), buffer_size, **kwargs)
 
     def get_combined_synapse_shape(self, Synapse_ID):
         """Get the population size along with the number of afferent synapses.
-        
+
         Args:
             Synapse_ID (str): The ID of the synapse by which it is registered in list of afferent synapses.
 
@@ -150,7 +152,7 @@ class NeuronGroup(NetworkObject):
 
     def subGroup(self, mask=None):
         """Get a NeuronSubGroup object from the population.
-        
+
         Args:
             mask (bool): The mask condition indicating which neurons to be included in the subgroup.
 
@@ -165,7 +167,7 @@ class NeuronGroup(NetworkObject):
 
     def get_masked_dict(self, dict_name, key):
         """Get value of a key in a specific dictionary attribute of the population.
-        
+
         Args:
             dict_name (str): Name of the dictionary.
             key (int or str): the key to retrieve from the dictionary.
@@ -185,7 +187,7 @@ class NeuronGroup(NetworkObject):
         search_behaviors=False,
     ):
         """Get a list of parameters of connected neuron groups.
-        
+
         Args:
             param_name (str): The name of the parameter.
             syn_tag (str): The tag of the synapse. The default is "All".
@@ -230,7 +232,7 @@ class NeuronGroup(NetworkObject):
 
     def partition(self, block_size=7):
         """Get a partitioned population.
-        
+
         Args:
             block_size (int): The size of each block. The default is 7.
 
@@ -248,7 +250,7 @@ class NeuronGroup(NetworkObject):
 
     def partition_masks(self, steps=[1, 1, 1]):
         """Get a mask tensor for partitioning the population.
-        
+
         Args:
             steps (list of int): The number of steps in each dimension. The default is [1, 1, 1].
 
@@ -293,7 +295,7 @@ class NeuronGroup(NetworkObject):
 
     def split_grid_into_sub_group_blocks(self, steps=[1, 1, 1]):
         """Split the population into partitioned subgroups.
-        
+
         Returns:
             list of NeuronGroup or NeuronSubGroup: The list of partitions.
         """
@@ -301,7 +303,7 @@ class NeuronGroup(NetworkObject):
 
     def get_subgroup_receptive_field_mask(self, subgroup, xyz_rf=[1, 1, 1]):
         """Get the receptive field mask of a neuron subgroup.
-        
+
         Args:
             subgroup (NeuronSubGroup or NeuronGroup): The neuron subgroup.
             xyz_rf (list of int): The receptive field size in each dimension. The default is [1, 1, 1].
@@ -333,7 +335,7 @@ class NeuronGroup(NetworkObject):
 
     def mask_var(self, var):
         """Mask a variable.
-        
+
         Args:
             var (torch.Tensor): The variable.
 
@@ -341,7 +343,7 @@ class NeuronGroup(NetworkObject):
             torch.Tensor: The masked variable.
         """
         return var
-    
+
     @property
     def def_dtype(self):
         return self.network.def_dtype
@@ -370,7 +372,6 @@ class NeuronSubGroup:
 
         attr = getattr(self.BaseNeuronGroup, attr_name)
         if type(attr) == torch.tensor:
-
             if attr.shape[0] != self.mask.shape[0]:
                 return attr[:, self.mask]
             else:
@@ -385,7 +386,6 @@ class NeuronSubGroup:
 
         attr = getattr(self.BaseNeuronGroup, attr_name)
         if type(attr) == torch.tensor:
-
             if attr.shape[0] != self.mask.shape[0]:
                 attr[:, self.mask] = value
             else:

--- a/pymonntorch/NetworkCore/NeuronGroup.py
+++ b/pymonntorch/NetworkCore/NeuronGroup.py
@@ -85,7 +85,7 @@ class NeuronGroup(NetworkObject):
             self.efferent_synapses[name] = []
 
     def get_neuron_vec(
-        self, mode="zeros()", scale=None, density=None, plot=False, **kwargs
+        self, mode="zeros()", scale=None, density=None, plot=False, dtype=None
     ):
         """Get a tensor with population's dimensionality.
 
@@ -102,7 +102,7 @@ class NeuronGroup(NetworkObject):
             scale (float): Scale of the tensor. The default is None (i.e. No scaling is applied).
             density (float): Density of the tensor. The default is None (i.e. dense tensor).
             plot (bool): If true, the histogram of the tensor will be plotted. The default is False.
-            kwargs (dict): Keyword arguments to be passed to the initialization function.
+            dtype (str or type): Data type of the tensor. If None, `def_dtype` will be used.
 
         Returns:
             torch.Tensor: The initialized tensor."""
@@ -112,7 +112,7 @@ class NeuronGroup(NetworkObject):
             scale=scale,
             density=density,
             plot=plot,
-            kwargs=kwargs,
+            dtype=dtype,
         )
 
     def get_neuron_vec_buffer(self, buffer_size, **kwargs):
@@ -341,6 +341,10 @@ class NeuronGroup(NetworkObject):
             torch.Tensor: The masked variable.
         """
         return var
+    
+    @property
+    def def_dtype(self):
+        return self.network.def_dtype
 
 
 class NeuronSubGroup:

--- a/pymonntorch/NetworkCore/SynapseGroup.py
+++ b/pymonntorch/NetworkCore/SynapseGroup.py
@@ -115,7 +115,7 @@ class SynapseGroup(NetworkObject):
         only_enabled=True,
         clone_along_first_axis=False,
         plot=False,
-        kwargs={},
+        dtype=None,
     ):
         """Get a tensor with synapse group dimensionality.
 
@@ -134,7 +134,7 @@ class SynapseGroup(NetworkObject):
             only_enabled (bool): Whether to only consider enabled synapses or not. The default is True.
             clone_along_first_axis (bool): Whether to clone the tensor along the first axis or not. The default is False.
             plot (bool): If true, the histogram of the tensor will be plotted. The default is False.
-            kwargs (dict): Keyword arguments to be passed to the initialization function.
+            dtype (str or type): Data type of the tensor. If None, `def_dtype` will be used.
 
         Returns:
             torch.Tensor: The initialized tensor.
@@ -145,7 +145,7 @@ class SynapseGroup(NetworkObject):
             scale=scale,
             density=density,
             plot=plot,
-            kwargs=kwargs,
+            dtype=dtype,
         )
 
         if clone_along_first_axis:
@@ -306,3 +306,7 @@ class SynapseGroup(NetworkObject):
                 setattr(result, key, copy.copy(sgd[key]))
 
         return result
+    
+    @property
+    def def_dtype(self):
+        return self.network.def_dtype

--- a/pymonntorch/NetworkCore/TaggableObject.py
+++ b/pymonntorch/NetworkCore/TaggableObject.py
@@ -1,7 +1,5 @@
 import torch
 
-def_dtype = torch.float32
-
 
 class TaggableObject(torch.nn.Module):
     """This is the base class for all taggable objects.
@@ -18,7 +16,7 @@ class TaggableObject(torch.nn.Module):
 
     def __init__(self, tag, device="cpu"):
         """Initialize the object.
-        
+
         Args:
             tag (str): Tag to add to the object. It can also be a comma-separated string of multiple tags.
             device (str): Device on which the object is located.

--- a/pymonntorch/NetworkCore/TaggableObject.py
+++ b/pymonntorch/NetworkCore/TaggableObject.py
@@ -35,6 +35,10 @@ class TaggableObject(torch.nn.Module):
             self.add_tag(tag)
         self.add_tag(self.__class__.__name__)
 
+    @property
+    def tag(self):
+        return self.tags[0]
+
     def has_module(self, tag):
         """Check if object has a module with a specific tag.
 

--- a/tests/test_pymonntorch.py
+++ b/tests/test_pymonntorch.py
@@ -21,9 +21,9 @@ def test_network_cpu_annotated():
     )
 
     class BasicBehavior(Behavior):
-        def set_variables(self, neurons):
-            super().set_variables(neurons)
-            neurons.voltage = neurons.get_neuron_vec(mode="zeros")
+        def initialize(self, neurons):
+            super().initialize(neurons)
+            neurons.voltage = neurons.vector(mode="zeros")
             self.threshold = 1.0
 
         def forward(self, neurons):
@@ -32,13 +32,13 @@ def test_network_cpu_annotated():
             neurons.voltage[firing] = 0.0  # reset
 
             neurons.voltage *= 0.9  # voltage decay
-            neurons.voltage += neurons.get_neuron_vec(mode="uniform", density=0.1)
+            neurons.voltage += neurons.vector(mode="uniform", density=0.1)
 
     class InputBehavior(Behavior):
-        def set_variables(self, neurons):
-            super().set_variables(neurons)
+        def initialize(self, neurons):
+            super().initialize(neurons)
             for synapse in neurons.afferent_synapses["GLUTAMATE"]:
-                synapse.W = synapse.get_synapse_mat("uniform", density=0.1)
+                synapse.W = synapse.matrix("uniform", density=0.1)
                 synapse.enabled = synapse.W > 0
 
         def forward(self, neurons):
@@ -80,9 +80,9 @@ def test_network_cuda_annotated():
     )
 
     class BasicBehavior(Behavior):
-        def set_variables(self, neurons):
-            super().set_variables(neurons)
-            neurons.voltage = neurons.get_neuron_vec(mode="zeros")
+        def initialize(self, neurons):
+            super().initialize(neurons)
+            neurons.voltage = neurons.vector(mode="zeros")
             self.threshold = 1.0
 
         def forward(self, neurons):
@@ -91,13 +91,13 @@ def test_network_cuda_annotated():
             neurons.voltage[firing] = 0.0  # reset
 
             neurons.voltage *= 0.9  # voltage decay
-            neurons.voltage += neurons.get_neuron_vec(mode="uniform", density=0.1)
+            neurons.voltage += neurons.vector(mode="uniform", density=0.1)
 
     class InputBehavior(Behavior):
-        def set_variables(self, neurons):
-            super().set_variables(neurons)
+        def initialize(self, neurons):
+            super().initialize(neurons)
             for synapse in neurons.afferent_synapses["GLUTAMATE"]:
-                synapse.W = synapse.get_synapse_mat("uniform", density=0.1)
+                synapse.W = synapse.matrix("uniform", density=0.1)
                 synapse.enabled = synapse.W > 0
 
         def forward(self, neurons):
@@ -106,7 +106,7 @@ def test_network_cuda_annotated():
                     synapse.W @ synapse.src.spike.float() / synapse.src.size * 10
                 )
 
-    net = Network(settings={'device': 'cuda'})
+    net = Network(settings={"device": "cuda"})
     ng = NeuronGroup(
         net=net,
         size=100,

--- a/tests/test_pymonntorch.py
+++ b/tests/test_pymonntorch.py
@@ -106,7 +106,7 @@ def test_network_cuda_annotated():
                     synapse.W @ synapse.src.spike.float() / synapse.src.size * 10
                 )
 
-    net = Network(device="cuda")
+    net = Network(settings={'device': 'cuda'})
     ng = NeuronGroup(
         net=net,
         size=100,


### PR DESCRIPTION
- fix the `_get_mat` bug not accepting integers.
- more efficient EventRecoder + accepting nD variables
- Recorder uses minimal dtype and warns on variable type change
- applying new PymoNNto naming convention 
- more efficient execution pipeline
- setting argument for network
- using `def_dtype` to change the default float percision