### PR TITLE
fix: docstring of an empty function

### DIFF
--- a/pymonntorch/NetworkCore/Behavior.py
+++ b/pymonntorch/NetworkCore/Behavior.py
@@ -193,7 +193,7 @@ class Behavior(TaggableObject):
             pass
 
         def empty_func_with_docstring():
-            # Empty function with docstring.
+            """Empty function with docstring."""
             pass
 
         def constants(f):


### PR DESCRIPTION
Comments do not change `co_code`